### PR TITLE
Add feet collision (bounce) and friction parameters.

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml
@@ -665,7 +665,37 @@ XMLBlobs:
         <gazebo reference="l_foot_ft_sensor">
           <disableFixedJointLumping>true</disableFixedJointLumping>
         </gazebo>
-  - | 
+  - |
+        <gazebo reference="l_foot">
+          <collision> <surface> <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>100000</threshold>
+          </bounce> </surface> </collision>
+          <maxContacts>4</maxContacts>
+          <kp>18000000</kp>
+          <kd>100</kd>
+          <maxVel>100</maxVel>
+          <minDepth>0.0001</minDepth>
+          <mu1>1</mu1>
+          <mu2>1</mu2>
+          <fdir1>0 0 0</fdir1>
+        </gazebo>
+  - |
+        <gazebo reference="r_foot">
+          <collision> <surface> <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>100000</threshold>
+          </bounce> </surface> </collision>
+          <maxContacts>4</maxContacts>
+          <kp>18000000</kp>
+          <kd>100</kd>
+          <maxVel>100</maxVel>
+          <minDepth>0.0001</minDepth>
+          <mu1>1</mu1>
+          <mu2>1</mu2>
+          <fdir1>0 0 0</fdir1>
+        </gazebo>
+  - |
         <gazebo>
         <plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
           <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_left_leg_mtb.ini</yarpConfigurationFile>

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options_NO_BACKPACK.yaml
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options_NO_BACKPACK.yaml
@@ -665,7 +665,37 @@ XMLBlobs:
         <gazebo reference="l_foot_ft_sensor">
           <disableFixedJointLumping>true</disableFixedJointLumping>
         </gazebo>
-  - | 
+  - |
+        <gazebo reference="l_foot">
+          <collision> <surface> <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>100000</threshold>
+          </bounce> </surface> </collision>
+          <maxContacts>4</maxContacts>
+          <kp>18000000</kp>
+          <kd>100</kd>
+          <maxVel>100</maxVel>
+          <minDepth>0.0001</minDepth>
+          <mu1>1</mu1>
+          <mu2>1</mu2>
+          <fdir1>0 0 0</fdir1>
+        </gazebo>
+  - |
+        <gazebo reference="r_foot">
+          <collision> <surface> <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>100000</threshold>
+          </bounce> </surface> </collision>
+          <maxContacts>4</maxContacts>
+          <kp>18000000</kp>
+          <kd>100</kd>
+          <maxVel>100</maxVel>
+          <minDepth>0.0001</minDepth>
+          <mu1>1</mu1>
+          <mu2>1</mu2>
+          <fdir1>0 0 0</fdir1>
+        </gazebo>
+  - |
         <gazebo>
         <plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
           <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_left_leg_mtb.ini</yarpConfigurationFile>


### PR DESCRIPTION
This change adds the `XML` blob in the `.yaml` config file that defines the collision (bounce) and friction parameters of the feet in the `URDF` file and targetted for **Gazebo**. The parameters are the same as the ones already used in the current iCub Gazebo model (`icub-gazebo/icub/icub.sdf`).

All parameters are defined for the `ODE` physics engine.

CONTACT:

kp       | kd | max_vel | min_depth | soft_erp      | soft_cfm
---------|----|---------|-----------|---------------|------------
18000000 | 1  | 100     | 0.0001    | 0.2 (default) | 0 (default)

FRICTION:

mu | mu2 | fdir  | slip1 | slip2
---|-----|-------|-------|------
1  | 1   | 0 0 0 | 0     | 0

BOUNCE:

restitution_coefficient | threshold
------------------------|----------
0 (inelastic)           | 100000
