### PR TITLE
Add the missing FT sensors plugin info in the yaml config files

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -863,6 +863,24 @@ XMLBlobs:
         <plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
           <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_torso_mtb.ini</yarpConfigurationFile>
         </plugin>
+        <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
+        </plugin>
+        <plugin name="left_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_foot_ft.ini</yarpConfigurationFile>
+        </plugin>
+        <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
+        </plugin>
+        <plugin name="right_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_foot_ft.ini</yarpConfigurationFile>
+        </plugin>
+        <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_arm_ft.ini</yarpConfigurationFile>
+        </plugin>
+        <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_arm_ft.ini</yarpConfigurationFile>
+        </plugin>
         <plugin name="controlboard_torso" filename="libgazebo_yarp_controlboard.so">
             <yarpConfigurationFile>model://iCub/conf/gazebo_icub_torso.ini</yarpConfigurationFile>
         </plugin>

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -438,16 +438,46 @@ linkFrames:
 forceTorqueSensors:
   - jointName: l_leg_ft_sensor
     directionChildToParent: Yes
+    sensorBlobs:
+    - |
+        <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
+        </plugin>
   - jointName: r_leg_ft_sensor
     directionChildToParent: Yes
+    sensorBlobs:
+    - |
+        <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
+        </plugin>
   - jointName: l_foot_ft_sensor
     directionChildToParent: Yes
+    sensorBlobs:
+    - |
+        <plugin name="left_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_foot_ft.ini</yarpConfigurationFile>
+        </plugin>
   - jointName: r_foot_ft_sensor
     directionChildToParent: Yes
+    sensorBlobs:
+    - |
+        <plugin name="right_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_foot_ft.ini</yarpConfigurationFile>
+        </plugin>
   - jointName: l_arm_ft_sensor
     directionChildToParent: Yes
+    sensorBlobs:
+    - |
+        <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_arm_ft.ini</yarpConfigurationFile>
+        </plugin>
   - jointName: r_arm_ft_sensor
     directionChildToParent: Yes
+    sensorBlobs:
+    - |
+        <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_arm_ft.ini</yarpConfigurationFile>
+        </plugin>
 
 sensors:
   - sensorName: default
@@ -863,46 +893,28 @@ XMLBlobs:
         <plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
           <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_torso_mtb.ini</yarpConfigurationFile>
         </plugin>
-        <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
-        </plugin>
-        <plugin name="left_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_foot_ft.ini</yarpConfigurationFile>
-        </plugin>
-        <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
-        </plugin>
-        <plugin name="right_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_foot_ft.ini</yarpConfigurationFile>
-        </plugin>
-        <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_arm_ft.ini</yarpConfigurationFile>
-        </plugin>
-        <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_arm_ft.ini</yarpConfigurationFile>
-        </plugin>
         <plugin name="controlboard_torso" filename="libgazebo_yarp_controlboard.so">
-            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_torso.ini</yarpConfigurationFile>
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_torso.ini</yarpConfigurationFile>
         </plugin>
         <plugin name="controlboard_head_without_eyes" filename="libgazebo_yarp_controlboard.so">
-            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_head_without_eyes.ini</yarpConfigurationFile>
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_head_without_eyes.ini</yarpConfigurationFile>
         </plugin>
         <plugin name="controlboard_left_arm_no_hand" filename="libgazebo_yarp_controlboard.so">
-            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
-            <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.698</initialConfiguration>
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
+          <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.698</initialConfiguration>
         </plugin>
         <plugin name="controlboard_right_arm_no_hand" filename="libgazebo_yarp_controlboard.so">
-            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
-            <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.698</initialConfiguration>
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
+          <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.698</initialConfiguration>
         </plugin>
         <plugin name="controlboard_right_leg" filename="libgazebo_yarp_controlboard.so">
-            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_leg.ini</yarpConfigurationFile>
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_leg.ini</yarpConfigurationFile>
         </plugin>
         <plugin name="controlboard_left_leg" filename="libgazebo_yarp_controlboard.so">
-            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_leg.ini</yarpConfigurationFile>
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_leg.ini</yarpConfigurationFile>
         </plugin>
         <plugin name="apply_external_wrench" filename="libgazebo_yarp_externalwrench.so" >
-             <robotNamefromConfigFile>model://iCub/conf/gazebo_icub_robotname.ini</robotNamefromConfigFile>
+          <robotNamefromConfigFile>model://iCub/conf/gazebo_icub_robotname.ini</robotNamefromConfigFile>
         </plugin>
         </gazebo>
   - |


### PR DESCRIPTION
Added the missing blobs in the `yaml` config files. This depends on the PR https://github.com/robotology/simmechanics-to-urdf/pull/32. In the absence of this dependency, the added blobs will be ignored.
(Can't add the dependency via **Zenhub** without disconnecting the repo `simmechanics-to-urdf` from the common board it is already connected to).