### PR TITLE
Set Model origin in generated iCub raw models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
   - cd build
   - export CMAKE_PREFIX_PATH=`pwd`/install
   # using the YCM_EP_MAINTAINER_MODE variable to enable the subproject-dependees target
-  - cmake -DCODYCO_TRAVIS_CI:BOOL=ON  -DYCM_EP_MAINTAINER_MODE:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE  ..
+  - cmake -DCODYCO_TRAVIS_CI:BOOL=ON  -DYCM_EP_MAINTAINER_MODE:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -D-DCODYCO_USES_KDL:BOOL=ON ..
   - cmake --build .
   - pwd
   - cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
   - cd build
   - export CMAKE_PREFIX_PATH=`pwd`/install
   # using the YCM_EP_MAINTAINER_MODE variable to enable the subproject-dependees target
-  - cmake -DCODYCO_TRAVIS_CI:BOOL=ON  -DYCM_EP_MAINTAINER_MODE:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -D-DCODYCO_USES_KDL:BOOL=ON ..
+  - cmake -DCODYCO_TRAVIS_CI:BOOL=ON  -DYCM_EP_MAINTAINER_MODE:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCODYCO_USES_KDL:BOOL=ON ..
   - cmake --build .
   - pwd
   - cd ../..

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -1,6 +1,10 @@
 # Robot name
 robotName: iCub
 
+# Model base origin
+originXYZ: [0.0,0.0,0.63]
+originRPY: [0.0,0.0,3.14]
+
 # Meshes options
 scale: "0.001 0.001 0.001"
 forcelowercase: Yes


### PR DESCRIPTION
Add the robot base link origin position and orientation parameters in the `YAML` config file. The parameters appear in the `yaml.in` as follows:
```
# Model base origin
originXYZ: [0.0,0.0,0.63]
originRPY: [0.0,0.0,3.14]
```
The respective tag generated in the URDF would then be:
```
  <gazebo>
    <pose>0.0 0.0 0.63 0.0 0.0 3.14</pose>
  </gazebo>
```
This allows the raw model to be dropped in the Gazebo simulator hovering 1mm above ground.
This belongs to the Epic https://github.com/robotology-playground/icub-model-generator/issues/79.