### PR TITLE
Add coupling matrices to the gazebo yarp plugin configuration files

### DIFF
--- a/simmechanics/data/icub2_5/conf/gazebo_icub_head.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_head.ini
@@ -19,6 +19,15 @@ head 0 5 0 5
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.000   1.000 
+-1.000   1.000) (
+ 1.000   0.000   0.000   0.000 
+ 0.000   1.000   0.000   0.000 
+ 0.000   0.000   1.000  -1.000 
+ 0.000   0.000   1.000   1.000)
+
 # Specify configuration of MotorControl devices
 [head]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_head_without_eyes.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_head_without_eyes.ini
@@ -19,6 +19,12 @@ head 0 2 0 2
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.000   1.000 
+-1.000   1.000) (
+ 1.000)
+
 # Specify configuration of MotorControl devices
 [head]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_no_hand.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_no_hand.ini
@@ -20,6 +20,16 @@ left_arm_no_hand 0 6 0 6
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.00    0.00    0.00    0.00 
+-1.625   1.625   0.00    0.00 
+ 0.00    0.00    1.625   0.00 
+ 0.00    0.00    0.00    1.00) (
+ 1.000   0.000   0.000 
+ 0.000   1.000   0.000 
+ 0.000  -1.000  +1.000)
+
 # Specify configuration of MotorControl devices
 [left_arm_no_hand]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini
@@ -20,6 +20,16 @@ left_arm_no_hand 0 6 0 6
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.00    0.00    0.00    0.00 
+-1.625   1.625   0.00    0.00 
+ 0.00    0.00    1.625   0.00 
+ 0.00    0.00    0.00    1.00) (
+ 1.000   0.000   0.000 
+ 0.000   1.000   0.000 
+ 0.000  -1.000  +1.000)
+
 # Specify configuration of MotorControl devices
 [left_arm_no_hand]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_left_leg.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_left_leg.ini
@@ -19,6 +19,15 @@ left_leg 0 5 0 5
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.00    0.00    0.00    0.00 
+ 0.00    1.00    0.00    0.00 
+ 0.00    0.00    1.00    0.00 
+ 0.00    0.00    0.00    1.00) (
+ 1.00    0.00 
+ 0.00    1.00)
+
 # Specify configuration of MotorControl devices
 [left_leg]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_no_hand.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_no_hand.ini
@@ -20,6 +20,16 @@ right_arm_no_hand 0 6 0 6
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.00    0.00    0.00    0.00 
+-1.625   1.625   0.00    0.00 
+ 0.00    0.00    1.625   0.00 
+ 0.00    0.00    0.00    1.00) (
+ 1.000   0.000   0.000 
+ 0.000   1.000   0.000 
+ 0.000  -1.000  +1.000)
+
 # Specify configuration of MotorControl devices
 [right_arm_no_hand]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini
@@ -20,6 +20,16 @@ right_arm_no_hand 0 6 0 6
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.00    0.00    0.00    0.00 
+-1.625   1.625   0.00    0.00 
+ 0.00    0.00    1.625   0.00 
+ 0.00    0.00    0.00    1.00) (
+ 1.000   0.000   0.000 
+ 0.000   1.000   0.000 
+ 0.000  -1.000  +1.000)
+
 # Specify configuration of MotorControl devices
 [right_arm_no_hand]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_right_leg.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_right_leg.ini
@@ -19,6 +19,15 @@ right_leg 0 5 0 5
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.00    0.00    0.00    0.00 
+ 0.00    1.00    0.00    0.00 
+ 0.00    0.00    1.00    0.00 
+ 0.00    0.00    0.00    1.00) (
+ 1.00    0.00 
+ 0.00    1.00)
+
 # Specify configuration of MotorControl devices
 [right_leg]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_torso.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_torso.ini
@@ -19,6 +19,12 @@ torso 0 2 0 2
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
+[COUPLING]
+matrixJ2M (
+ 1.000   -1.000    0.000 
+ 1.000    1.000    0.000 
+-1.000    0.000    1.820)
+
 # Specify configuration of MotorControl devices
 [torso]
 # name of the device to be instatiated by the factory


### PR DESCRIPTION
Add coupling matrices to the gazebo yarp plugin configuration files. During a simulation of iCub on Gazebo, these coupling matrices will be exposed by the Gazebo Yarp plugins as remote debug variables `kinematic_mj` through the interface `yarp::dev::IRemoteVariables`.

The matrices have been directly copied from the iCub hardware configuration files from the `robots-configuration` repository `iCubGenova04/hardware/mechanicals/<part>-<board>-<joints>-mec.xml`. For instance, in `head-eb20-j0_1-mec.xml`:
```
     <group name="COUPLINGS">

        <param name ="matrixJ2M">
            1.000   1.000   0.000   0.000
           -1.000   1.000   0.000   0.000
            0.000   0.000   1.000   0.000
            0.000   0.000   0.000   1.000
        </param>

        <param name ="matrixM2J">
            0.500  -0.500   0.000   0.000
            0.500   0.500   0.000   0.000
            0.000   0.000   1.000   0.000
            0.000   0.000   0.000   1.000
        </param>

        <param name ="matrixE2J">
            1.00    0.00    0.00    0.00    0.00    0.00
            0.00    1.00    0.00    0.00    0.00    0.00
            0.00    0.00    1.00    0.00    0.00    0.00
            0.00    0.00    0.00    1.00    0.00    0.00
        </param>

    </group>
```
`matrixJ2M` is the matrix converting joint positions/velocities into motor positions/velocities, defined in http://wiki.icub.org/wiki/ICub_coupled_joints by:
```
m = T⁻¹ q
```
and exposed by the `yarp::dev::IRemoteVariables` interface as the variable `kinematic_mj`.

The values in the iCub hardware configuration files don't match those from the wiki. Actually the values have been adjusted for some Firmware purposes (refer to more details in [this discussion thread](https://github.com/robotology/robots-configuration/issues/39)).
The values shall be updated in the future according to the ongoing discussions or any required fixes. The intention here is to reproduce the parameters used on the iCub current configuration. These coupling matrices will be handled by the ControlBoard device driver implemented in the Gazebo Yarp Plugins. 