### PR TITLE
Revert "Add coupling matrices to the gazebo yarp plugin configuration files"

### DIFF
--- a/simmechanics/data/icub2_5/conf/gazebo_icub_head.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_head.ini
@@ -19,15 +19,6 @@ head 0 5 0 5
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.000   1.000 
--1.000   1.000) (
- 1.000   0.000   0.000   0.000 
- 0.000   1.000   0.000   0.000 
- 0.000   0.000   1.000  -1.000 
- 0.000   0.000   1.000   1.000)
-
 # Specify configuration of MotorControl devices
 [head]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_head_without_eyes.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_head_without_eyes.ini
@@ -19,12 +19,6 @@ head 0 2 0 2
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.000   1.000 
--1.000   1.000) (
- 1.000)
-
 # Specify configuration of MotorControl devices
 [head]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_no_hand.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_no_hand.ini
@@ -20,16 +20,6 @@ left_arm_no_hand 0 6 0 6
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.00    0.00    0.00    0.00 
--1.625   1.625   0.00    0.00 
- 0.00    0.00    1.625   0.00 
- 0.00    0.00    0.00    1.00) (
- 1.000   0.000   0.000 
- 0.000   1.000   0.000 
- 0.000  -1.000  +1.000)
-
 # Specify configuration of MotorControl devices
 [left_arm_no_hand]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini
@@ -20,16 +20,6 @@ left_arm_no_hand 0 6 0 6
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.00    0.00    0.00    0.00 
--1.625   1.625   0.00    0.00 
- 0.00    0.00    1.625   0.00 
- 0.00    0.00    0.00    1.00) (
- 1.000   0.000   0.000 
- 0.000   1.000   0.000 
- 0.000  -1.000  +1.000)
-
 # Specify configuration of MotorControl devices
 [left_arm_no_hand]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_left_leg.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_left_leg.ini
@@ -19,15 +19,6 @@ left_leg 0 5 0 5
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.00    0.00    0.00    0.00 
- 0.00    1.00    0.00    0.00 
- 0.00    0.00    1.00    0.00 
- 0.00    0.00    0.00    1.00) (
- 1.00    0.00 
- 0.00    1.00)
-
 # Specify configuration of MotorControl devices
 [left_leg]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_no_hand.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_no_hand.ini
@@ -20,16 +20,6 @@ right_arm_no_hand 0 6 0 6
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.00    0.00    0.00    0.00 
--1.625   1.625   0.00    0.00 
- 0.00    0.00    1.625   0.00 
- 0.00    0.00    0.00    1.00) (
- 1.000   0.000   0.000 
- 0.000   1.000   0.000 
- 0.000  -1.000  +1.000)
-
 # Specify configuration of MotorControl devices
 [right_arm_no_hand]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini
@@ -20,16 +20,6 @@ right_arm_no_hand 0 6 0 6
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.00    0.00    0.00    0.00 
--1.625   1.625   0.00    0.00 
- 0.00    0.00    1.625   0.00 
- 0.00    0.00    0.00    1.00) (
- 1.000   0.000   0.000 
- 0.000   1.000   0.000 
- 0.000  -1.000  +1.000)
-
 # Specify configuration of MotorControl devices
 [right_arm_no_hand]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_right_leg.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_right_leg.ini
@@ -19,15 +19,6 @@ right_leg 0 5 0 5
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.00    0.00    0.00    0.00 
- 0.00    1.00    0.00    0.00 
- 0.00    0.00    1.00    0.00 
- 0.00    0.00    0.00    1.00) (
- 1.00    0.00 
- 0.00    1.00)
-
 # Specify configuration of MotorControl devices
 [right_leg]
 # name of the device to be instatiated by the factory

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_torso.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_torso.ini
@@ -19,12 +19,6 @@ torso 0 2 0 2
 [TRAJECTORY_GENERATION]
 trajectory_type minimum_jerk
 
-[COUPLING]
-matrixJ2M (
- 1.000   -1.000    0.000 
- 1.000    1.000    0.000 
--1.000    0.000    1.820)
-
 # Specify configuration of MotorControl devices
 [torso]
 # name of the device to be instatiated by the factory


### PR DESCRIPTION
Reverts robotology-playground/icub-model-generator#87 .
Necessary to fix https://github.com/robotology-playground/icub-model-generator/issues/89 .