### PR TITLE
Add iCubManchester01 generation

### DIFF
--- a/dh/CMakeLists.txt
+++ b/dh/CMakeLists.txt
@@ -22,6 +22,9 @@ generate_icub_dh(YARP_ROBOT_NAME iCubNancy01
 generate_icub_dh(YARP_ROBOT_NAME iCubLisboa01
                  PARTS_VERSIONS headV2-armsV1-legsV1-feetV1)
 
+generate_icub_dh(YARP_ROBOT_NAME iCubManchester01
+                 PARTS_VERSIONS headV1-armsV1-legsV1-feetV1)
+
 add_custom_target(generate-models-dh
                   ALL
                   DEPENDS ${model-dh-generated-models})

--- a/dh/data/legacy_models/headV1-armsV1-legsV1-feetV1/model.urdf
+++ b/dh/data/legacy_models/headV1-armsV1-legsV1-feetV1/model.urdf
@@ -1206,26 +1206,6 @@
         <parent link="l_upper_arm"/>
         <child link="l_arm_ft"/>
     </joint>
-    <link name="l_arm_ft"/>
-    <joint name="l_arm_ft_fixed_joint" type="fixed">
-        <parent link="l_upper_arm"/>
-        <child link="l_arm_ft"/>
-    </joint>
-    <link name="r_arm_ft"/>
-    <joint name="r_arm_ft_fixed_joint" type="fixed">
-        <parent link="r_upper_arm"/>
-        <child link="r_arm_ft"/>
-    </joint>
-    <link name="l_arm_ft"/>
-    <joint name="l_arm_ft_fixed_joint" type="fixed">
-        <parent link="l_upper_arm"/>
-        <child link="l_arm_ft"/>
-    </joint>
-    <link name="l_arm_ft"/>
-    <joint name="l_arm_ft_fixed_joint" type="fixed">
-        <parent link="l_upper_arm"/>
-        <child link="l_arm_ft"/>
-    </joint>
     <link name="r_arm_ft"/>
     <joint name="r_arm_ft_fixed_joint" type="fixed">
         <parent link="r_upper_arm"/>

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,7 +32,7 @@ configure_cmake_project = { cmd = "cmake -GNinja -S. -B.build -DICUB_MODELS_SOUR
 generate_models = { cmd = "cmake --build .build --target generate-models",  depends_on = ["configure_cmake_project"]}
 copy_models_to_icub_models = { cmd = "cmake --build .build --target copy-models-to-icub-models",  depends_on = ["configure_cmake_project"]}
 build_tests = { cmd = "cmake --build .build", depends_on = ["configure_cmake_project"] }
-test_generated_models = { cmd = "ctest --test-dir .build",  depends_on = ["generate_models", "build_tests"]}
+test_generated_models = { cmd = "ctest --output-on-failure --test-dir .build",  depends_on = ["generate_models", "build_tests"]}
 
 [dependencies]
 # We need a version where https://github.com/robotology/idyntree/pull/1191

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ if( ICUB_MODEL_GENERATE_DH )
     add_icub_model_test(iCubGenova03)
     add_icub_model_test(iCubNancy01)
     add_icub_model_test(iCubLisboa01)
+    add_icub_model_test(iCubManchester01)
 endif()
 
 # Model generated with simmechanics

--- a/tests/icub-model-test.cpp
+++ b/tests/icub-model-test.cpp
@@ -493,7 +493,8 @@ bool isModelWithoutFTSensorInAnkles(const std::string& modelPath)
 {
     return (modelPath.find("Genova03") != std::string::npos ||
             modelPath.find("Nancy01") != std::string::npos ||
-            modelPath.find("Lisboa01") != std::string::npos);
+            modelPath.find("Lisboa01") != std::string::npos ||
+            modelPath.find("Manchester01") != std::string::npos);
 }
 
 std::vector<std::string> getFTSensorNames(const std::string& modelPath)
@@ -565,7 +566,7 @@ bool checkAllFTMeasurementFrameGivenBySensorTagsIsCoherentWithMeasurementFrameGi
     {
         std::cerr << "icub-model-test : checkAllFTMeasurementFrameGivenBySensorTagsIsCoherentWithMeasurementFrameGivenByFrame test performed correctly " << std::endl;
     }
-    
+
     return ok;
 }
 


### PR DESCRIPTION
See:
- https://github.com/robotology/icub-models/issues/267

This PR adds the URDF of `iCubManchester01`, the sensors are missing/control_board are missing, we need to understand with the users what they need